### PR TITLE
Edited SaGa Wikipedia page

### DIFF
--- a/scripts/people/ArcticSphinx.yaml
+++ b/scripts/people/ArcticSphinx.yaml
@@ -6,3 +6,4 @@
   irc: ArcticSphinx
   name: Joseph Prezioso
   rit_dce: jxp8159
+  commcont1: https://en.wikipedia.org/w/index.php?title=SaGa_%28series%29&diff=prev&oldid=597870230


### PR DESCRIPTION
Added updated information to the 'Legacy' section. Apparently, the series' 25th anniversary is in December of 2014, and Akitoshi Kawazu (the series' creator) hinted at an announcement.
