### PR TITLE
Updating hack1 link

### DIFF
--- a/scripts/people/Fangy.yaml
+++ b/scripts/people/Fangy.yaml
@@ -8,4 +8,4 @@
   rit_dce: lle6138
   hackprop1: http://nerdyworldproblems.wordpress.com/2014/02/13/hack-proposal-1/
   commcont1: http://nerdyworldproblems.wordpress.com/2014/03/04/community-contributions-and-rocwiki/
-  hack1: https://pypi.python.org/pypi/BarkTracker/
+  hack1: http://nerdyworldproblems.wordpress.com/2014/03/16/pypi/

--- a/scripts/people/Fangy.yaml
+++ b/scripts/people/Fangy.yaml
@@ -8,4 +8,4 @@
   rit_dce: lle6138
   hackprop1: http://nerdyworldproblems.wordpress.com/2014/02/13/hack-proposal-1/
   commcont1: http://nerdyworldproblems.wordpress.com/2014/03/04/community-contributions-and-rocwiki/
-  hack1: https://github.com/lle6138/BarkTracker
+  hack1: https://pypi.python.org/pypi/BarkTracker/


### PR DESCRIPTION
Now links to pypi instead of github repo

edit: now links to blog?? D: confused.
