### PR TITLE
Add links for hack1 and hackprop2

### DIFF
--- a/scripts/people/mansam.yaml
+++ b/scripts/people/mansam.yaml
@@ -8,5 +8,7 @@
   irc: mansam
   name: Sam Lucidi
   rit_dce: sxl6435
-  hackprop1: http://mansam.github.io/articles/sprint1-project-proposal.html
+  hackprop1: http://www.samlucidi.com/fossrit-proposal-for-sprint-1.html
   bugfix: http://www.samlucidi.com/fossrit-bugfix-assignment.html
+  hack1: http://www.samlucidi.com/hotdate-intuitive-date-formatting.html
+  hackprop2: http://www.samlucidi.com/fossrit-proposal-for-sprint-2.html


### PR DESCRIPTION
Also updates hackprop1's use of an out-of-date url scheme.
