### PR TITLE
Commcont3 added

### DIFF
--- a/scripts/people/ArcticSphinx.yaml
+++ b/scripts/people/ArcticSphinx.yaml
@@ -11,3 +11,4 @@
   hack1: https://pypi.python.org/pypi/BarkTracker/0.1.0
   hackprop2: http://joeprezioso.wordpress.com/2014/04/01/hack-proposal-2-neuropi/
   commcont2: http://joeprezioso.wordpress.com/2014/04/09/arm-to-begin-using-open-source-compiler/
+  commcont3: http://https://en.wikipedia.org/w/index.php?title=Durarara!!&diff=prev&oldid=607031840


### PR DESCRIPTION
I edited Durarara!!'s Wikipedia page to make note of the fact that the second season, titled Durarara!! SH, will be set 2 years after the first season.

I feel that this is important information, as skipping ahead 2 years after the end of the first season means that there is a significant span of time in which major changes could have taken place off-screen--though anything of such great significance will likely come up in a flashback.
