### PR TITLE
-Add a better description on main page (in site.yaml) (Fixes #113)

### DIFF
--- a/advfoss/site.yaml
+++ b/advfoss/site.yaml
@@ -1,11 +1,11 @@
 course:
     name: ADVFOSS
-    desc: The RIT Seminar in IGM Course
+    desc: "This is the website for ADVFOSS, the Advanced Projects in Free/Open Source Development at RIT. Students develop tightly-scoped projects, also known as hacks, using open technologies and released under open licenses."
     place: RIT
     start: 2014-01-27
     end: 2014-05-17
     times: "Tues & Thurs 2:00pm - 3:15pm"
-    course: "4085.580.03"
+    course: "IGME-590"
     location: "Orange Hall (ORN)-1380"
 
 instructor:

--- a/advfoss/templates/about.mak
+++ b/advfoss/templates/about.mak
@@ -1,9 +1,8 @@
 <%inherit file="master.mak"/>
 
 <div class="jumbotron">
-<h1>Hello, world!</h1>
-<p>This is a wonderful experiment using Twitter Boostrap, Flask, and Mako to make awesome.</p>
-<p><a href="#" class="btn btn-primary btn-lg">Learn more &raquo;</a></p>
+<h1>About This Site</h1>
+<p>This spirit of free and open source culture runs deep in ADVFOSS. Everything is open source, from the lectures to the syllabus to this website. Below we list the technology stack this site uses.</p>
 </div>
 
 <div class="row">

--- a/advfoss/templates/home.mak
+++ b/advfoss/templates/home.mak
@@ -3,4 +3,5 @@
 <div class="jumbotron">
     <h1>${course['name']}</h1>
     <p>${course['desc']}</p>
+    <p><a href="/syllabus" class="btn btn-primary btn-lg">Learn more &raquo;</a></p>
 </div>

--- a/advfoss/templates/hw/final.mak
+++ b/advfoss/templates/hw/final.mak
@@ -56,7 +56,7 @@
     <h2>Finished Project <span class="label label-primary">20%</span></h2>
     <ul>
     <li>Your grade here will be derived from the following factors (adjusted
-    for progress over the quarter):</li>
+    for progress over the semester):</li>
     <ul>
         <li>Is the code clearly licensed under an OSI-compatible license?</li>
         <li>Does your source repository contain clear written instructions for

--- a/advfoss/templates/master.mak
+++ b/advfoss/templates/master.mak
@@ -36,7 +36,6 @@
           <a target="_blank" href="http://github.com/decause/advfoss" class="navbar-link">Fork me on GitHub</a>
         </p>
         <ul class="nav navbar-nav">
-          <li><a href="/about">About</a></li>
           <li><a href="/syllabus">Syllabus</a></li>
           <li><a href="/oer">Resources</a></li>
           <li><a href="/lectures">Lectures</a></li>
@@ -44,6 +43,7 @@
           <li><a href="/decause">Instructor</a></li>
           <li><a href="/checkblogs">Participants</a></li>
           <li><a target="_blank" href="http://webchat.freenode.net/?&amp;channels=rit-foss">Instant IRC</a></li>
+          <li><a href="/about">About Site</a></li>
         </ul>
       </div><!--/.nav-collapse -->
     </nav>

--- a/advfoss/templates/syllabus.mak
+++ b/advfoss/templates/syllabus.mak
@@ -82,7 +82,7 @@ course will have three tightly scoped project releases (or "hacks".)
 <p>Assignments are due at 4:59pm of the day they are marked as due, to be useful in class.</p>
 <p>Late submissions will be deducted <span class="label label-danger">10%</span> per day they are late.</p>
 <hr class="docutils">
-<p>Your final grade for the quarter will be derived from the following weights.</p>
+<p>Your final grade for the semester will be derived from the following weights.</p>
 <table class="docutils" border="1">
 <colgroup>
 <col style="width: 80%;">
@@ -179,7 +179,7 @@ course will have three tightly scoped project releases (or "hacks".)
     <h2>Finished Project <span class="label label-primary">20%</span></h2>
     <ul>
     <li>Your grade here will be derived from the following factors (adjusted
-    for progress over the quarter):</li>
+    for progress over the semester):</li>
     <ul>
         <li>Is the code clearly licensed under an OSI-compatible license?</li>
         <li>Does your source repository contain clear written instructions for

--- a/scripts/people/ChrisKnepper.yaml
+++ b/scripts/people/ChrisKnepper.yaml
@@ -1,6 +1,6 @@
-# Hi!  I am ChrisKnepper
-- blog: http://beta.chrisknepper.com/category/foss/
-  feed: http://beta.chrisknepper.com/category/foss/feed/
+# Hi! I am ChrisKnepper
+- blog: http://beta.chrisknepper.com/tag/afoss_post/
+  feed: http://beta.chrisknepper.com/tag/afoss_post/feed/
   forges:
     - http://github.com/chrisknepper
   irc: ChrisKnepper
@@ -10,5 +10,11 @@
   commcont1: http://beta.chrisknepper.com/2014/03/helping-out-without-code/
   hack1: http://beta.chrisknepper.com/2014/03/introducing-entropy-a-pythonic-wallpaper-rater/
   hackprop2: http://beta.chrisknepper.com/2014/03/advanced-foss-project-2-proposal/
-  commcont2: http://beta.chrisknepper.com/2014/05/open-source-interview/
-  commcont3: http://beta.chrisknepper.com/2014/05/introducing-catbug-a-threaded-http-request-library/
+  commcont2: http://beta.chrisknepper.com/2014/05/introducing-catbug-a-threaded-http-request-library/
+  hack2: http://beta.chrisknepper.com/2014/05/introducing-in-glass-a-temperature-monitoring-and-logging-utility/
+  lightningtalk1: https://docs.google.com/presentation/d/1mH0QgzZKVazCb-UFEWgMTs_4yy9toaOR9le2bYndP5Q/
+  lightningtalk2: https://docs.google.com/presentation/d/1s_dczvrD2ZfZ_mCRnJzcYVTLXqg9EBYR0-3ESb8AMrg/
+  hackathon1: http://beta.chrisknepper.com/2014/04/a-bar-and-a-camp-walk-into-a-university/
+  hackathon2: http://beta.chrisknepper.com/2014/04/pax-your-bags/
+  hackathon3: http://beta.chrisknepper.com/2014/05/homestretch-runner/
+  hackathon4: http://beta.chrisknepper.com/2014/05/when-kids-want-to-learn/


### PR DESCRIPTION
-Replace all instances of the word "quarter" with "semester" (Fixes #140)
-Move "Learn more" button from about page to main page and link to syllabus (previously went nowhere)
-Add better description on about page
-Move about page to end of navigation row (it's less important than the other pages)
-Update course number to be correct
-Update my yaml file with final links and updated feed, including bonus lightning talks and hackathons

I went through my blog and switched from using a category to using a tag for posts I made for this class. I also added my missing links and assignments, though some of the blog posts have existed for a while. I apologize for the delay in this pull request.
